### PR TITLE
Fix for issue where resource group name was not being assigned for single resourcegroup users

### DIFF
--- a/CDP-Retail/artifacts/environment-setup/automation/01-environment-setup.ps1
+++ b/CDP-Retail/artifacts/environment-setup/automation/01-environment-setup.ps1
@@ -92,6 +92,10 @@ if($resourceGroups.GetType().IsArray -and $resourceGroups.length -gt 1){
     $resourceGroupName = $resourceGroups[$selectedRgIdx]
     Write-Information "Selecting the $selectedRgName resource group"
 }
+else{
+$resourceGroupName=$resourceGroups
+Write-Information "Selecting the $resourceGroupName resource group"
+}
 
 $uniqueId = (Get-AzResource -ResourceGroupName $resourceGroupName -ResourceType Microsoft.Synapse/workspaces).Name.Replace("asaexpworkspace", "")
 $subscriptionId = (Get-AzContext).Subscription.Id


### PR DESCRIPTION
Issue faced in labs environment where user gets only single resource group in the list. Have added the else condition to handle this scenario.