### PR TITLE
Added 24 character limit to Key Vault Name.

### DIFF
--- a/fsidemo/fsiSetup.ps1
+++ b/fsidemo/fsiSetup.ps1
@@ -182,7 +182,11 @@ $iot_hub_name = "iothub-fsi-$suffix"
 $asa_name_fsi = "fsiasa-$suffix"
 $eventhub_evh_namespace_name = "evh-namespace--$suffix"
 $storageAccountName = $dataLakeAccountName
-$keyVaultName = "kv-$suffix";
+$keyVaultName = "kv-$suffix"
+if($keyVaultName.length -gt 24)
+{
+$keyVaultName = $keyVaultName.substring(0,24)
+}
 $amlworkspacename = "amlws-$suffix"
 $cog_speech_name = "speech-service-$suffix"
 $cog_translator_name = "translator-$suffix"

--- a/fsidemo/mainTemplate.json
+++ b/fsidemo/mainTemplate.json
@@ -81,7 +81,7 @@
     "app_realtime_kpi_simulator_app_service_name": "[concat('app-fsi-realtime-kpi-simulator-',variables('unique_suffix'))]",
     "cogs_forms_name": "[concat('forms-',variables('unique_suffix'))]",
     "search_fsi_demo_name": "[concat('srch-fsi-',variables('unique_suffix'))]",
-    "key_vault_name": "[concat('kv-',variables('unique_suffix'))]",
+    "key_vault_name": "[substring(concat('kv-',variables('unique_suffix')),0,24)]",
     "databricks_workspace_name": "[concat('fsi-dbrs-',variables('unique_suffix'))]",
     "databricks_managed_resource_group_name": "[concat('rg-', variables('databricks_workspace_name'))]",
     "cog_speech_name": "[concat('speech-service-',variables('unique_suffix'))]",


### PR DESCRIPTION
There is a 24 character limit to Key Vault Names.  Deploying the fsiSetup.ps1 script worked successfully except for the Key Vault with an error specifying the Key Vault Name could not be deployed because the Key Vault Name was greater than 24 characters.  Confirmed in the Microsoft Docs the Key Vault Name needs to be between 3 and 24 characters.  Therefore, added a limit to 24 characters in the same way other resources had their character count limited using substring.