### PR TITLE
Update resourceCleanup.ps1

### DIFF
--- a/Manufacturing/automation/resourceCleanup.ps1
+++ b/Manufacturing/automation/resourceCleanup.ps1
@@ -1,19 +1,18 @@
-$rgName = read-host "Enter the resource Group Name to be deleted";
+$rgName = Read-Host "Enter the Resource Group Name to be deleted"
 $subs = Get-AzSubscription | Select-Object -ExpandProperty Name
 
-if($subs.GetType().IsArray -and $subs.length -gt 1)
-{
-    $subOptions = [System.Collections.ArrayList]::new()
-    for($subIdx=0; $subIdx -lt $subs.length; $subIdx++)
-    {
-        $opt = New-Object System.Management.Automation.Host.ChoiceDescription "$($subs[$subIdx])", "Selects the $($subs[$subIdx]) subscription."   
-        $subOptions.Add($opt)
+if ($subs.Count -gt 1) {
+    $subOptions = @()
+    for ($subIdx = 0; $subIdx -lt $subs.Count; $subIdx++) {
+        $opt = New-Object System.Management.Automation.Host.ChoiceDescription "$($subs[$subIdx])", "Selects the $($subs[$subIdx]) subscription"
+        $subOptions += $opt
     }
-    $selectedSubIdx = $host.ui.PromptForChoice('Enter the desired Azure Subscription for this lab','Copy and paste the name of the subscription to make your choice.', $subOptions.ToArray(),0)
+    $selectedSubIdx = $host.ui.PromptForChoice('Enter the desired Azure Subscription for this lab', 'Copy and paste the name of the subscription to make your choice', $subOptions, 0)
     $selectedSubName = $subs[$selectedSubIdx]
     Write-Host "Selecting the $selectedSubName subscription"
-    Select-AzSubscription -SubscriptionName $selectedSubName
-    az account set --subscription $selectedSubName
+    Select-AzSubscription -SubscriptionName $selectedSubName | Out-Null
+    az account set --subscription $selectedSubName | Out-Null
 }
+
 az group delete --no-wait --name $rgName
 Write-Host "Deletion Completed"


### PR DESCRIPTION
The code now uses the Count property instead of the length property to check the number of subscriptions. This ensures compatibility with both single subscriptions and arrays of subscriptions.

The $subOptions array is initialized using the @() syntax for consistency.

The $subOptions array now uses the += operator to add elements to the array instead of the Add method for better performance.

The Select-AzSubscription and az account set commands have been silenced using | Out-Null to suppress unnecessary output.