### PR TITLE
KQL fixes

### DIFF
--- a/fabric/artifacts/kqlscripts/01_Query_Thermostat_Data_in_Near_Real-time_using_KQL_Script.kql
+++ b/fabric/artifacts/kqlscripts/01_Query_Thermostat_Data_in_Near_Real-time_using_KQL_Script.kql
@@ -2,14 +2,14 @@
 
 //What is the average temperature every 1 min?
 
-Thermostat
+thermostat
 | where EnqueuedTimeUTC > ago(2d)
 | where DeviceId == 'TH005'
 | summarize avg(Temp) by bin(EnqueuedTimeUTC,1m)
 | render timechart 
 
 //What will be the temperature for next 15 Minutes?
-Thermostat
+thermostat
 | where EnqueuedTimeUTC > ago(2d)
 | where DeviceId == 'TH005'
 | make-series AvgTemp=avg(Temp) default=real(null) on EnqueuedTimeUTC from ago(2d) to now()+15m step 1m   
@@ -19,7 +19,7 @@ Thermostat
 | render timechart with(title='Forecasting the next 15min by Time Series Decmposition')
 
 //Are there any anomalies for this device?
-Thermostat 
+thermostat 
 | where EnqueuedTimeUTC > ago(12h)
 | where DeviceId == 'TH005'
 | make-series AvgTemp=avg(Temp) default=real(null) on EnqueuedTimeUTC from ago(12h) to now() step 1m   

--- a/fabric/artifacts/kqlscripts/02_Analyze_Consumers_E-commerce_Website_Purchasing_Behaviour.kql
+++ b/fabric/artifacts/kqlscripts/02_Analyze_Consumers_E-commerce_Website_Purchasing_Behaviour.kql
@@ -11,17 +11,6 @@ Behaviour
 
 
 // Search items in userscart not in shopping list
-OnlineBehaviour 
-| join kind=leftouter ShoppingCheckoutList on product_id
-|where isnull(product_id1) and category_code!=(' ') and user_id=='539920214'
-| count(category_code)
-
-
-Select SC.category_code,count(SC.category_code) from OnlineBehaviour OB join
-ShoppingCheckoutList SC on SC.product_id=OB.product_id
-group by SC.category_code
-
-
 OnlineBehaviour
 | join kind=leftouter (
     ShoppingCheckoutList


### PR DESCRIPTION
Small fixes to the kql scripts to make them run smoothly during a demo. table name needs to be in lowercase, as that's what created during setup. also, sql scripts have no place in kql querysets. if you want to keep them, then at least comment them out. 