### PR TITLE
add sleep for permissions & memberships to propagate

### DIFF
--- a/fabric/fabricSetup.ps1
+++ b/fabric/fabricSetup.ps1
@@ -498,7 +498,10 @@ else {
     
     $credential = New-Object PSCredential($appId, (ConvertTo-SecureString $clientsecpwdapp -AsPlainText -Force))
 
-   # Connect to Power BI using the service principal
+    Write-Host "... waiting some 5 minutes for permissions to propagate"
+    start-sleep -s 300
+
+    # Connect to Power BI using the service principal
     Connect-PowerBIServiceAccount -ServicePrincipal -Credential $credential -TenantId $tenantId
 
     $PowerBIFiles = Get-ChildItem "./artifacts/reports" -Recurse -Filter *.pbix


### PR DESCRIPTION
I kept on running into errors when it tries to upload the reports. After adding sleep, it worked without problems.